### PR TITLE
Update tf-nightly requirement to 2.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ mdx_truly_sane_lists
 sphinx~=3.0.3
 black==19.10b0
 pathlib
-tf-nightly==2.2.0.dev20200508
+tf-nightly~=2.3.0.dev20200610


### PR DESCRIPTION
2.2 is no longer available.  Using [compatible release clause](https://www.python.org/dev/peps/pep-0440/#compatible-release) `~=` will allow pip to find the latest 2.3 nightly

See https://github.com/keras-team/keras-io/issues/149#issuecomment-659465308